### PR TITLE
Fix: Use cross-compiler strip command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC := $(CROSS_COMPILE)gcc
+STRIP := $(CROSS_COMPILE)strip
 CFLAGS := -Wall -Wextra -Werror -O2
 
 ifeq ($(STATIC),1)
@@ -11,7 +12,8 @@ all: makerw
 
 makerw: makerw.c
 	$(CC) $(CFLAGS) -o $@ $<
-	strip $@
+	$(STRIP) $@
 
 clean:
 	rm -f makerw
+	


### PR DESCRIPTION
* Add STRIP variable to use the cross-compiler strip command.
* Update makerw target to use the STRIP variable instead of the default strip command.